### PR TITLE
When destroying, forget also the oauth_token and oauth_token secret from...

### DIFF
--- a/src/Pingpong/Twitter/Twitter.php
+++ b/src/Pingpong/Twitter/Twitter.php
@@ -268,6 +268,7 @@ class Twitter
 	{
 		$this->session->forget('oauth_token');
 		$this->session->forget('oauth_token_secret');
+		$this->setNewOAuthToken(null, null);
 		return $this;
 	}
 


### PR DESCRIPTION
I just added a line to also forget the oauth_token and oauth_token_secret from the base twitter instance when calling destroy. This prevents the 401 error in the autorization when another oauth_token was previously set.
