### PR TITLE
Erreur for upload method

### DIFF
--- a/src/Pingpong/Twitter/Traits/HumanTrait.php
+++ b/src/Pingpong/Twitter/Traits/HumanTrait.php
@@ -42,7 +42,7 @@ trait HumanTrait {
     {
         $data = array('status' => $status, 'media[]' => $media) + $parameters;
 
-        return $this->postSpostStatusesUpdateWithMedia($data, $appOnlyAuth);
+        return $this->postStatusesUpdateWithMedia($data, $appOnlyAuth);
     }
 
     /**


### PR DESCRIPTION
Instead of postStatusesUpdateWithMedia we have postSpostStatusesUpdateWithMedia so we've got Call to undefined method Pingpong\Twitter\Twitter::postSpostStatusesUpdateWithMedia()
