### PR TITLE
Fix publish for first installation

### DIFF
--- a/src/Pingpong/Twitter/TwitterServiceProvider.php
+++ b/src/Pingpong/Twitter/TwitterServiceProvider.php
@@ -25,7 +25,9 @@ class TwitterServiceProvider extends ServiceProvider {
 			__DIR__ . '/../../config/config.php' => $configPath
 		]);
 
-		$this->mergeConfigFrom($configPath, 'twitter');
+		if (is_file($configPath)) {
+			$this->mergeConfigFrom($configPath, 'twitter');
+		}
 	}
 
 	/**


### PR DESCRIPTION
```
php artisan vendor:publish --provider="Pingpong\Twitter\TwitterServiceProvider"
PHP Warning:  Uncaught exception 'ErrorException' with message 'require(/vagrant/project/config/twitter.php): failed to open stream: No such file or directory' in /vagrant/project/vendor/laravel/framework/src/Illuminate/Support/ServiceProvider.php:64
```